### PR TITLE
Docs: move environment variables to developers guide

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -2,6 +2,20 @@
 
 This document provides instructions for developers who want to contribute to MorphCards or run it in a containerized environment. For user documentation, please see the [main README file](README.md).
 
+## 🔑 Environment Variables
+
+**This documentation assumes Gemini is being used by default.** All examples assume you have a `.env` file with your API keys.
+
+**Create a `.env` file in your project root:**
+```bash
+# .env file
+GEMINI_API_KEY=your-gemini-api-key-here
+GEMINI_MODEL_NAME=gemini-2.5-flash # Example: gemini-2.5-flash, gemini-1.5-pro, gemini-1.5-flash
+
+#OPENAI_API_KEY=your-openai-api-key-here  # Uncomment for OpenAI
+#OPENAI_MODEL_NAME=gpt-3.5-turbo # Example: gpt-4, gpt-3.5-turbo
+```
+
 ## 🚀 Quick Demo (One Command)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,20 +33,6 @@ pip install morphcards
 pip install morphcards[demo]
 ```
 
-### Environment Variables
-
-**This documentation assumes Gemini is being used by default.** All examples assume you have a `.env` file with your API keys.
-
-**Create a `.env` file in your project root:**
-```bash
-# .env file
-GEMINI_API_KEY=your-gemini-api-key-here
-GEMINI_MODEL_NAME=gemini-2.5-flash # Example: gemini-2.5-flash, gemini-1.5-pro, gemini-1.5-flash
-
-#OPENAI_API_KEY=your-openai-api-key-here  # Uncomment for OpenAI
-#OPENAI_MODEL_NAME=gpt-3.5-turbo # Example: gpt-4, gpt-3.5-turbo
-```
-
 ### Basic Usage
 
 ```python


### PR DESCRIPTION
The "Environment Variables" section has been moved from README.md to DEVELOPERS.md.

This change further cleans up the README.md for end-users, while keeping important setup information for developers.